### PR TITLE
Support for else if

### DIFF
--- a/src/syntax/parser/mod.rs
+++ b/src/syntax/parser/mod.rs
@@ -666,6 +666,9 @@ where
 				self.step();
 
 				let (condition, then, otherwise) = self.parse_condblock()?;
+				
+				self.expect(TokenKind::Keyword(Keyword::End))
+					.with_sync(sync::Strategy::keyword(Keyword::End))?;
 
 				Ok(ast::Expr::If {
 					condition: condition.into(),
@@ -766,7 +769,7 @@ where
 		let otherwise = match self.token.take() {
 			Some(token) => match token {
 				Token { kind: TokenKind::Keyword(Keyword::End), .. } => {
-					self.step();
+					self.token = Some(token);
 					Ok(ast::Block::default())
 				},
 				Token { kind: TokenKind::Keyword(Keyword::Else), .. } => {
@@ -789,9 +792,6 @@ where
 						x => {
 							self.token = x;
 							let block = self.parse_block();
-
-							self.expect(TokenKind::Keyword(Keyword::End))
-								.with_sync(sync::Strategy::keyword(Keyword::End))?;
 
 							Ok(block)
 						}

--- a/src/syntax/parser/mod.rs
+++ b/src/syntax/parser/mod.rs
@@ -772,11 +772,11 @@ where
 					self.token = Some(token);
 					Ok(ast::Block::default())
 				},
-				Token { kind: TokenKind::Keyword(Keyword::Else), .. } => {
+				Token { kind: TokenKind::Keyword(Keyword::Else), pos: elsepos, .. } => {
 					self.step();
 
 					match self.token.take() {
-						Some(Token { kind: TokenKind::Keyword(Keyword::If), pos, .. }) => {
+						Some(Token { kind: TokenKind::Keyword(Keyword::If), pos: ifpos, .. }) if elsepos.line == ifpos.line => {
 							self.step();
 							let (condition, then, otherwise) = self.parse_condblock()?;
 
@@ -784,7 +784,7 @@ where
 								condition: condition.into(),
 								then: then,
 								otherwise: otherwise,
-								pos,
+								pos: ifpos,
 							});
 		
 							Ok(ast::Block::Block(Box::new([stmt])))


### PR DESCRIPTION
An purely syntactical implementation of `else if`.
Supports for all the following forms:
```
if <expr> then
  ...
end
```
```
if <expr> then
  ...
else
  ...
end
```
```
if <expr> then
  ...
else if <expr> then
  ...
else
  ...
end
```
```
if <expr> then
  ...
else
  if <expr> then
    ...
  end
end
```